### PR TITLE
Fix vcard parse export

### DIFF
--- a/src/BaselineOfICal/BaselineOfICal.class.st
+++ b/src/BaselineOfICal/BaselineOfICal.class.st
@@ -23,7 +23,9 @@ BaselineOfICal >> baseline: spec [
 			group: 'Core' with: #('ICal');
 			group: 'VCard' with: #('Core' 'ICal-VCard');
 			group: 'Tests' with: #('VCard' 'ICal-Tests');
-			group: 'default' with: #('VCard' 'Tests') ]
+			group: 'VCardTests' with: #('Tests' 'ICal-VCard-Tests');
+
+ 			group: 'default' with: #('VCard' 'VCardTests') ]
 ]
 
 { #category : 'baselines' }

--- a/src/ICal-Tests/ICConversionTest.class.st
+++ b/src/ICal-Tests/ICConversionTest.class.st
@@ -294,12 +294,12 @@ ICConversionTest >> testParseStringOldEncoding [
 	| string value |
 	ICCalendarVersion use: 1.0 during: [
 		string := 'Bar Street 99=0AFootown 12345=0AFooland'.
-		value := String fromICalString: string.
+		value := String fromOldString: string.
 		self assert: value equals: 'Bar Street 99
 Footown 12345
 Fooland'.
 		self
-			assert: value asICalString
+			assert: value asOldICalString
 			equals: 'Bar Street 99=0D=0AFootown 12345=0D=0AFooland' ]
 ]
 
@@ -310,13 +310,12 @@ ICConversionTest >> testParseStringOldEncodingAndSpaces [
 	ICCalendarVersion use: 1.0 during: [
 		string := '123 Winding Way=0D=0A=' , String crlf
 		          , ' Any Town, CA 12345=0D=0A=' , String crlf , ' USA'.
-		value := String fromICalString:
-			         (ICCalendarHandParser new unfold: string).
+		value := String fromOldString: (ICCalendarHandParser new unfold: string).
 		self assert: value equals: '123 Winding Way
 Any Town, CA 12345
 USA'.
 		self
-			assert: value asICalString
+			assert: value asOldICalString
 			equals: '123 Winding Way=0D=0AAny Town\\, CA 12345=0D=0AUSA' ]
 ]
 

--- a/src/ICal-VCard-Tests/ICVCardConversionTest.class.st
+++ b/src/ICal-VCard-Tests/ICVCardConversionTest.class.st
@@ -12,57 +12,57 @@ ICVCardConversionTest >> testAddress [
 	address := ICAddress fromVCardString: string parameters: Dictionary new.
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
-	self assert: address street = '123 Main Street'.
-	self assert: address locality = 'Any Town'.
-	self assert: address postalcode = '91921-1234'.
-	self assert: address region = 'CA'.
+	self assert: address street equals: '123 Main Street'.
+	self assert: address locality equals: 'Any Town'.
+	self assert: address postalcode equals: '91921-1234'.
+	self assert: address region equals: 'CA'.
 	self assert: address country isEmptyOrNil.
-	self assert: address asVCardString = string.	
+	self assert: address asVCardString equals: string.	
 
 	string := ';;501 E. Middlefield Rd.;Mountain View;CA;94043;U.S.A.'.
 	address := ICAddress fromVCardString: string parameters: Dictionary new.
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
-	self assert: address street = '501 E. Middlefield Rd.'.
-	self assert: address locality = 'Mountain View'.
-	self assert: address postalcode = '94043'.
-	self assert: address region = 'CA'.
-	self assert: address country = 'U.S.A.'.
-	self assert: address asVCardString = string.
+	self assert: address street equals: '501 E. Middlefield Rd.'.
+	self assert: address locality equals: 'Mountain View'.
+	self assert: address postalcode equals: '94043'.
+	self assert: address region equals: 'CA'.
+	self assert: address country equals: 'U.S.A.'.
+	self assert: address asVCardString equals: string.
 
 	string := ';;6544 Battleford Drive;Raleigh;NC;27613-3502;U.S.A.'.
 	address := ICAddress fromVCardString: string parameters: Dictionary new.
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
-	self assert: address street = '6544 Battleford Drive'.
-	self assert: address locality = 'Raleigh'.
-	self assert: address postalcode = '27613-3502'.
-	self assert: address region = 'NC'.
-	self assert: address country = 'U.S.A.'.
-	self assert: address asVCardString = string.
+	self assert: address street equals: '6544 Battleford Drive'.
+	self assert: address locality equals: 'Raleigh'.
+	self assert: address postalcode equals: '27613-3502'.
+	self assert: address region equals: 'NC'.
+	self assert: address country equals: 'U.S.A.'.
+	self assert: address asVCardString equals: string.
 ]
 
 { #category : 'testing' }
 ICVCardConversionTest >> testDate [
 	| date |
 	date := self dateClass year: 1985 month: 04 day: 12.
-	self assert: date asVCardString = '1985-04-12'.
+	self assert: date asVCardString equals: '1985-04-12'.
 
 	date :=  self dateClass year: 1996 month: 08 day: 05.
-	self assert: date asVCardString = '1996-08-05'.
+	self assert: date asVCardString equals: '1996-08-05'.
 
 	date :=  self dateClass year: 1996 month: 11 day: 11.
-	self assert: date asVCardString = '1996-11-11'.
+	self assert: date asVCardString equals: '1996-11-11'.
 ]
 
 { #category : 'testing' }
 ICVCardConversionTest >> testDateAndTime [
 	| dateAndTime |
 	dateAndTime := self dateAndTimeClass year: 1996 month: 10 day: 22 hour: 14 minute: 00 second: 00.
-	self assert: '1996-10-22T14:00:00'  = dateAndTime asVCardString.
+	self assert: '1996-10-22T14:00:00' equals: dateAndTime asVCardString.
 	
 	dateAndTime := self dateAndTimeClass year: 1996 month: 08 day: 11 hour: 12 minute: 34 second: 56.
-	self assert: '1996-08-11T12:34:56'  = dateAndTime asVCardString.
+	self assert: '1996-08-11T12:34:56' equals: dateAndTime asVCardString.
 ]
 
 { #category : 'testing' }
@@ -92,19 +92,19 @@ ICVCardConversionTest >> testParseDate [
 	| string date |
 	string := '1985-04-12'.
 	date := self dateClass fromVCardString: string.
-	self assert: date = (self dateClass year: 1985 month: 04 day: 12).
+	self assert: date equals: (self dateClass year: 1985 month: 04 day: 12).
 
 	string := '1996-08-05'.
 	date := self dateClass fromVCardString: string.
-	self assert: date = (self dateClass year: 1996 month: 08 day: 05).
+	self assert: date equals: (self dateClass year: 1996 month: 08 day: 05).
 
 	string := '1996-11-11'.
 	date := self dateClass fromVCardString: string.
-	self assert: date = (self dateClass year: 1996 month: 11 day: 11).
+	self assert: date equals: (self dateClass year: 1996 month: 11 day: 11).
 
 	string := '19850412'.
 	date := self dateClass fromVCardString: string.
-	self assert: date = (self dateClass year: 1985 month: 04 day: 12).
+	self assert: date equals: (self dateClass year: 1985 month: 04 day: 12).
 ]
 
 { #category : 'testing' }
@@ -112,56 +112,56 @@ ICVCardConversionTest >> testParseDateAndTime [
 	| string dateAndTime |
 	string := '1996-10-22T14:00:00Z'.
 	dateAndTime := self dateAndTimeClass fromVCardString: string.
-	self assert: dateAndTime = (self dateAndTimeClass year: 1996 month: 10 day: 22 hour: 14 minute: 00 second: 00).
+	self assert: dateAndTime equals: (self dateAndTimeClass year: 1996 month: 10 day: 22 hour: 14 minute: 00 second: 00).
 
 	string := '1996-08-11T12:34:56Z'.
 	dateAndTime := self dateAndTimeClass fromVCardString: string.
-	self assert: dateAndTime = (self dateAndTimeClass year: 1996 month: 08 day: 11 hour: 12 minute: 34 second: 56).
+	self assert: dateAndTime equals: (self dateAndTimeClass year: 1996 month: 08 day: 11 hour: 12 minute: 34 second: 56).
 
 	string := '19960811T123456Z'.
 	dateAndTime := self dateAndTimeClass fromVCardString: string.
-	self assert: dateAndTime = (self dateAndTimeClass year: 1996 month: 08 day: 11 hour: 12 minute: 34 second: 56).
+	self assert: dateAndTime equals: (self dateAndTimeClass year: 1996 month: 08 day: 11 hour: 12 minute: 34 second: 56).
 ]
 
 { #category : 'testing' }
 ICVCardConversionTest >> testParseTime [
 	| time string |
 	time := self timeClass hour: 10 minute: 22 second: 00.
-	self assert: '10:22:00'  = time asVCardString.
+	self assert: '10:22:00' equals: time asVCardString.
 	
 	string := '10:22:00'.
 	time := self timeClass hour: 10 minute: 22 second: 00.
-	self assert: (self timeClass fromVCardString: string) = time.
+	self assert: (self timeClass fromVCardString: string) equals: time.
 	
 	string := '102200'.
 	time := self timeClass hour: 10 minute: 22 second: 00.
-	self assert: (self timeClass fromVCardString: string) = time.
+	self assert: (self timeClass fromVCardString: string) equals: time.
 	
 	string := '10:22:00.33'.
 	time := self timeClass hour: 10 minute: 22 second: 00 nanosecond: 330000000.
-	self assert: (self timeClass fromVCardString: string) = time.
-	self assert: time asVCardString = string.
+	self assert: (self timeClass fromVCardString: string) equals: time.
+	self assert: time asVCardString equals: string.
 	
 	string := '10:22:00.33Z'.
 	time := self timeClass hour: 10 minute: 22 second: 00 nanosecond: 330000000.
-	self assert: (self timeClass fromVCardString: string) = time.
-	self assert: time asVCardUtcString = string.
+	self assert: (self timeClass fromVCardString: string) equals: time.
+	self assert: time asVCardUtcString equals: string.
 	
 	string := '10:22:00-08:00'.
 	time := self timeClass hour: 10 minute: 22 second: 00.
-	self assert: (self timeClass fromVCardString: string) = time.
+	self assert: (self timeClass fromVCardString: string) equals: time.
 ]
 
 { #category : 'testing' }
 ICVCardConversionTest >> testTime [
 	| time |
 	time := self timeClass hour: 10 minute: 22 second: 00.
-	self assert: time asVCardString = '10:22:00'.
+	self assert: time asVCardString equals: '10:22:00'.
 
 	time := self timeClass hour: 10 minute: 22 second: 00 nanosecond: 330000000.
-	self assert: time asVCardString = '10:22:00.33'.
+	self assert: time asVCardString equals: '10:22:00.33'.
 
 	time :=self timeClass hour: 10 minute: 22 second: 33.
-	self assert: time asVCardString = '10:22:33'.
+	self assert: time asVCardString equals: '10:22:33'.
 
 ]

--- a/src/ICal-VCard-Tests/ICVCardExportLineTest.class.st
+++ b/src/ICal-VCard-Tests/ICVCardExportLineTest.class.st
@@ -8,7 +8,7 @@ Class {
 	#package : 'ICal-VCard-Tests'
 }
 
-{ #category : 'running' }
+{ #category : 'private' }
 ICVCardExportLineTest >> performTest [
 	ICCardVersion 
 		use: 2.1
@@ -18,18 +18,23 @@ ICVCardExportLineTest >> performTest [
 
 { #category : 'running' }
 ICVCardExportLineTest >> setUp [
+
+	super setUp.
 	vCardExporter := ICVCardExporter new
 	
 ]
 
 { #category : 'testing' }
 ICVCardExportLineTest >> testExportExactlyThreeLines [
+	"This test seems to check that each exported line does not exceed the length of 75 characters"
 	| line expected |
-	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'.
+	
+	
+	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt'.
 	expected :=
-		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt=', String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt=', String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt' , String crlf.
+		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt', String crlf,
+		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt', String crlf,
+		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt' , String crlf.
 
 	self assert: (vCardExporter exportLine: line) dataStream contents equals: expected.
 ]
@@ -39,24 +44,32 @@ ICVCardExportLineTest >> testExportExactlyTwoLines [
 
 	| line expected |
 	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'.
-	expected :=
-		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt=', String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt', String crlf.
-	
-	self assert: (vCardExporter exportLine: line) dataStream contents = expected.
+	expected := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'
+	            , String crlf
+	            ,
+	            ' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'
+	            , String crlf.
+	self
+		assert: (vCardExporter exportLine: line) dataStream contents
+		equals: expected
 ]
 
 { #category : 'testing' }
 ICVCardExportLineTest >> testExportFourLines [
+
 	| line expected |
 	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt fff ggg hhh'.
-	expected :=
-		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt=', String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt=' , String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt=' , String crlf,
-		'  fff ggg hhh', String crlf.
-
-	self assert: (vCardExporter exportLine: line) dataStream contents = expected.
+	expected := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'
+	            , String crlf
+	            ,
+	            ' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt'
+	            , String crlf
+	            ,
+	            ' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt'
+	            , String crlf , '  fff ggg hhh' , String crlf.
+	self
+		assert: (vCardExporter exportLine: line) dataStream contents
+		equals: expected
 ]
 
 { #category : 'testing' }
@@ -64,20 +77,24 @@ ICVCardExportLineTest >> testExportThreeLines [
 
 	| line expected |
 	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttttaaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt fff ggg hhh'.
-	expected := 
-		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt=', String crlf,
-		' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt=', String crlf,
-		'  fff ggg hhh', String crlf.
-	
-	self assert: (vCardExporter exportLine: line) dataStream contents = expected.
+	expected := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'
+	            , String crlf
+	            ,
+	            ' aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx ttt'
+	            , String crlf , '  fff ggg hhh' , String crlf.
+	self
+		assert: (vCardExporter exportLine: line) dataStream contents
+		equals: expected
 ]
 
 { #category : 'testing' }
 ICVCardExportLineTest >> testExportTwoLines [
+
 	| line expected |
 	line := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt fff ggg hhh'.
-	expected :=
-		'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt=', String crlf,
-		'  fff ggg hhh', String crlf.
-	self assert: (vCardExporter exportLine: line) dataStream contents = expected.
+	expected := 'aaabbbcccddd dddcccbbbaaa zzz yyy xxx xxx yyy zzz bla foo bar xyz zyx tttt'
+	            , String crlf , '  fff ggg hhh' , String crlf.
+	self
+		assert: (vCardExporter exportLine: line) dataStream contents
+		equals: expected
 ]

--- a/src/ICal-VCard-Tests/ICVCardTest.class.st
+++ b/src/ICal-VCard-Tests/ICVCardTest.class.st
@@ -700,49 +700,49 @@ ICVCardTest >> testParseAvi [
 ICVCardTest >> testParseEric [
 	| cards card name imid |
 	cards := ICCardHandParser parseVCardString: self ericCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Eric Wahlforss'.
-	self assert: card title = 'Entrepreneur / Musician'.
-	self assert: card url asVCardString = 'http://eric.wahlforss.com/'.
-	self assert: card version = 3.0.
+	self assert: card fullname equals: 'Eric Wahlforss'.
+	self assert: card title equals: 'Entrepreneur / Musician'.
+	self assert: card url asVCardString equals: 'http://eric.wahlforss.com/'.
+	self assert: card version equals: 3.0.
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Wahlforss'.
-	self assert: name givenName = 'Eric'.
+	self assert: name familyName equals: 'Wahlforss'.
+	self assert: name givenName equals: 'Eric'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card aimids size = 1.	
+	self assert: card aimids size equals: 1.	
 	imid := card aimids anyOne.
 	self assert: (imid isKindOf: ICAIMId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'ericwahlforss'.
+	self assert: imid id equals: 'ericwahlforss'.
 	
-	self assert: card icqids size = 1.	
+	self assert: card icqids size equals: 1.	
 	imid := card icqids anyOne.
 	self assert: (imid isKindOf: ICICQId).
 	self assert: imid isPreferred.
 	self assert: imid isWork.
 	self deny: imid isHome.
-	self assert: imid id = '5399905'.
+	self assert: imid id equals: '5399905'.
 	
-	self assert: card msnids size = 1.
+	self assert: card msnids size equals: 1.
 	imid := card msnids anyOne.
 	self assert: (imid isKindOf: ICMSNId).
 	self deny: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'ericwahlforss@hotmail.com'.
+	self assert: imid id equals: 'ericwahlforss@hotmail.com'.
 	
 	self assert: card yahooids isEmpty.
 	
-	self assert: card categories size = 1.
-	self assert: card categories anyOne summary = '24HDC'
+	self assert: card categories size equals: 1.
+	self assert: card categories anyOne summary equals: '24HDC'
 	
 ]
 
@@ -750,21 +750,21 @@ ICVCardTest >> testParseEric [
 ICVCardTest >> testParseGoofy [
 	| cards card address name phoneNumber |
 	cards := ICCardHandParser parseVCardString: self goofyCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Markus Tschannen'.
-	self assert: card version = 2.1.
-	self assert: card birthday = (self dateClass year: 1980 month: 10 day: 30).
+	self assert: card fullname equals: 'Markus Tschannen'.
+	self assert: card version equals: 2.1.
+	self assert: card birthday equals: (self dateClass year: 1980 month: 10 day: 30).
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Tschannen'.
-	self assert: name givenName = 'Markus'.
+	self assert: name familyName equals: 'Tschannen'.
+	self assert: name givenName equals: 'Markus'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card addresses size = 1.
+	self assert: card addresses size equals: 1.
 	address := card addresses anyOne.
 	
 	self assert: address isHome.
@@ -778,15 +778,15 @@ ICVCardTest >> testParseGoofy [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = 'Neufeldstrasse 11'.
-	self assert: address locality = 'Bern'.
+	self assert: address street equals: 'Neufeldstrasse 11'.
+	self assert: address locality equals: 'Bern'.
 	self assert: address region isEmptyOrNil.
-	self assert: address postalcode = '3012'.
-	self assert: address country = 'Schweiz'.
+	self assert: address postalcode equals: '3012'.
+	self assert: address country equals: 'Schweiz'.
 	
-	self assert: card phoneNumbers size = 2.
+	self assert: card phoneNumbers size equals: 2.
 	phoneNumber := card phoneNumbers first.
-	self assert: phoneNumber number = '+41 31 302 08 56'.
+	self assert: phoneNumber number equals: '+41 31 302 08 56'.
 	self assert: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -801,7 +801,7 @@ ICVCardTest >> testParseGoofy [
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers second.
-	self assert: phoneNumber number = '+41 78 845 24 12'.
+	self assert: phoneNumber number equals: '+41 78 845 24 12'.
 	self assert: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -817,48 +817,48 @@ ICVCardTest >> testParseGoofy [
 	
 	self assert: card emailAddresses isEmpty.
 	self assert: (card timeZone isKindOf: String).
-	self assert: (card timeZone = '-05:00; EST; Raleigh/North America').
-	self assert: card geo = (37.386013@ (-122.082932))
+	self assert: card timeZone equals: '-05:00; EST; Raleigh/North America'.
+	self assert: card geo equals: (37.386013@ (-122.082932))
 ]
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testParseMaeve [
 	| cards card name imid |
 	cards := ICCardHandParser parseVCardString: self maeveCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Maeve Price'.
-	self assert: card title = 'Digital Editor'.
-	self assert: card version = 3.0.
+	self assert: card fullname equals: 'Maeve Price'.
+	self assert: card title equals: 'Digital Editor'.
+	self assert: card version equals: 3.0.
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Price'.
-	self assert: name givenName = 'Maeve'.
+	self assert: name familyName equals: 'Price'.
+	self assert: name givenName equals: 'Maeve'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card aimids size = 1.
+	self assert: card aimids size equals: 1.
 	imid := card aimids anyOne.
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'Mahaevey'.
+	self assert: imid id equals: 'Mahaevey'.
 	
 	self assert: card icqids isEmpty.
 	
-	self assert: card msnids size = 1.
+	self assert: card msnids size equals: 1.
 	imid := card msnids anyOne.
 	self assert: (imid isKindOf: ICMSNId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'dgu186@hotmail.com'.
+	self assert: imid id equals: 'dgu186@hotmail.com'.
 	
 	self assert: card yahooids isEmpty.
 	
-	self assert: card categories size = 3.
+	self assert: card categories size equals: 3.
 	#('Friends' 'Columbia College Chicago' 'Family') do: [ :each |
 		self assert: (card categories anySatisfy: [ :cat | cat summary = each  ]) ].
 	
@@ -886,19 +886,19 @@ ICVCardTest >> testParseOscar [
 	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Oscar2 Nierstrasz'.
-	self assert: card version = 3.0.
-	self assert: card title = 'Professor'.
+	self assert: card fullname equals: 'Oscar2 Nierstrasz'.
+	self assert: card version equals: 3.0.
+	self assert: card title equals: 'Professor'.
 	
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Nierstrasz'.
-	self assert: name givenName = 'Oscar'.
+	self assert: name familyName equals: 'Nierstrasz'.
+	self assert: name givenName equals: 'Oscar'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card addresses size = 3.
+	self assert: card addresses size equals: 3.
 	address := card addresses first.
 	
 	self deny: address isHome.
@@ -912,13 +912,13 @@ ICVCardTest >> testParseOscar [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = 'Software Composition Group
+	self assert: address street equals: 'Software Composition Group
 IAM, University of Bern
 Neubrueckstrasse 10'.
-	self assert: address locality = 'Bern'.
+	self assert: address locality equals: 'Bern'.
 	self assert: address region isEmptyOrNil.
-	self assert: address postalcode = 'CH-3012'.
-	self assert: address country = 'SWITZERLAND'.
+	self assert: address postalcode equals: 'CH-3012'.
+	self assert: address country equals: 'SWITZERLAND'.
 	
 	address := card addresses second.
 	
@@ -933,11 +933,11 @@ Neubrueckstrasse 10'.
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = 'Fluhmattweg 41'.
-	self assert: address locality = 'Kehrsatz'.
+	self assert: address street equals: 'Fluhmattweg 41'.
+	self assert: address locality equals: 'Kehrsatz'.
 	self assert: address region isEmptyOrNil.
-	self assert: address postalcode = '3122'.
-	self assert: address country = 'SWITZERLAND'.
+	self assert: address postalcode equals: '3122'.
+	self assert: address country equals: 'SWITZERLAND'.
 	
 	address := card addresses third.
 	
@@ -952,15 +952,15 @@ Neubrueckstrasse 10'.
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = 'Schuetzenmattstrasse 14, room 103'.
+	self assert: address street equals: 'Schuetzenmattstrasse 14, room 103'.
 	self assert: address locality isEmptyOrNil.
 	self assert: address region isEmptyOrNil.
 	self assert: address postalcode isEmptyOrNil.
 	self assert: address country isEmptyOrNil.
 	
-	self assert: card phoneNumbers size = 3.
+	self assert: card phoneNumbers size equals: 3.
 	phoneNumber := card phoneNumbers first.
-	self assert: phoneNumber number = '+41 31 631.4618'.
+	self assert: phoneNumber number equals: '+41 31 631.4618'.
 	self deny: phoneNumber isHome.
 	self assert: phoneNumber isPreferred.
 	self assert: phoneNumber isWork.
@@ -975,7 +975,7 @@ Neubrueckstrasse 10'.
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers second.
-	self assert: phoneNumber number = '+41 31 961.7065'.
+	self assert: phoneNumber number equals: '+41 31 961.7065'.
 	self assert: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -990,7 +990,7 @@ Neubrueckstrasse 10'.
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers third.
-	self assert: phoneNumber number = '+41 31 631.3355'.
+	self assert: phoneNumber number equals: '+41 31 631.3355'.
 	self deny: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self assert: phoneNumber isWork.
@@ -1004,9 +1004,9 @@ Neubrueckstrasse 10'.
 	self deny: phoneNumber isVoice.
 	self deny: phoneNumber isVoiceMessage.
 	
-	self assert: card emailAddresses size = 1.
+	self assert: card emailAddresses size equals: 1.
 	emailAddress := card emailAddresses first.
-	self assert: emailAddress address = 'oscar.nierstrasz@acm.org'.
+	self assert: emailAddress address equals: 'oscar.nierstrasz@acm.org'.
 	self assert: emailAddress isWork.
 	self assert: emailAddress isPreferred.
 	self deny: emailAddress isHome.
@@ -1014,7 +1014,7 @@ Neubrueckstrasse 10'.
 	self deny: emailAddress isX400.
 	
 	organization := card organization.
-	self assert: organization name = 'University of Bern'.
+	self assert: organization name equals: 'University of Bern'.
 	self assert: organization unitNames isEmpty.
 ]
 
@@ -1022,10 +1022,10 @@ Neubrueckstrasse 10'.
 ICVCardTest >> testParseOscarUrl [
 	| cards card |
 	cards := ICCardHandParser parseVCardString: self oscarCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 
-	self assert: card url asVCardString = 'http://www.iam.unibe.ch/~oscar/'.
+	self assert: card url asVCardString equals: 'http://www.iam.unibe.ch/~oscar/'.
 	
 ]
 
@@ -1033,22 +1033,22 @@ ICVCardTest >> testParseOscarUrl [
 ICVCardTest >> testParseSean [
 	| cards card address name phoneNumber emailAddress organization |
 	cards := ICCardHandParser parseVCardString: self seanCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Sean Glazier'.
-	self assert: card version = 2.1.
-	self assert: card title = 'Lead Software Engineer'.
-	self assert: card birthday = (self dateClass year: 2005 month: 10 day: 01).
+	self assert: card fullname equals: 'Sean Glazier'.
+	self assert: card version equals: 2.1.
+	self assert: card title equals: 'Lead Software Engineer'.
+	self assert: card birthday equals: (self dateClass year: 2005 month: 10 day: 01).
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Glazier'.
-	self assert: name givenName = 'Sean'.
+	self assert: name familyName equals: 'Glazier'.
+	self assert: name givenName equals: 'Sean'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card addresses size = 2.
+	self assert: card addresses size equals: 2.
 	address := card addresses first.
 	
 	self deny: address isHome.
@@ -1062,11 +1062,11 @@ ICVCardTest >> testParseSean [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = '6 Christie Lane'.
-	self assert: address locality = 'Stratham'.
-	self assert: address region = 'NH'.
-	self assert: address postalcode = '03885'.
-	self assert: address country = 'USA'.
+	self assert: address street equals: '6 Christie Lane'.
+	self assert: address locality equals: 'Stratham'.
+	self assert: address region equals: 'NH'.
+	self assert: address postalcode equals: '03885'.
+	self assert: address country equals: 'USA'.
 	
 	address := card addresses second.
 	
@@ -1081,15 +1081,15 @@ ICVCardTest >> testParseSean [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = '6 Christie Lane'.
-	self assert: address locality = 'Stratham'.
-	self assert: address region = 'NH'.
-	self assert: address postalcode = '03885'.
-	self assert: address country = 'USA'.
+	self assert: address street equals: '6 Christie Lane'.
+	self assert: address locality equals: 'Stratham'.
+	self assert: address region equals: 'NH'.
+	self assert: address postalcode equals: '03885'.
+	self assert: address country equals: 'USA'.
 	
-	self assert: card phoneNumbers size = 4.
+	self assert: card phoneNumbers size equals: 4.
 	phoneNumber := card phoneNumbers first.
-	self assert: phoneNumber number = '603 772 4480'.
+	self assert: phoneNumber number equals: '603 772 4480'.
 	self deny: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self assert: phoneNumber isWork.
@@ -1104,7 +1104,7 @@ ICVCardTest >> testParseSean [
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers second.
-	self assert: phoneNumber number = '603 770 8260'.
+	self assert: phoneNumber number equals: '603 770 8260'.
 	self deny: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -1119,7 +1119,7 @@ ICVCardTest >> testParseSean [
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers third.
-	self assert: phoneNumber number = '603 772 2852'.
+	self assert: phoneNumber number equals: '603 772 2852'.
 	self assert: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -1134,7 +1134,7 @@ ICVCardTest >> testParseSean [
 	self deny: phoneNumber isVoiceMessage.
 	
 	phoneNumber := card phoneNumbers fourth.
-	self assert: phoneNumber number = '603 770 8260'.
+	self assert: phoneNumber number equals: '603 770 8260'.
 	self deny: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -1148,9 +1148,9 @@ ICVCardTest >> testParseSean [
 	self assert: phoneNumber isVoice.
 	self deny: phoneNumber isVoiceMessage.
 	
-	self assert: card emailAddresses size = 2.
+	self assert: card emailAddresses size equals: 2.
 	emailAddress := card emailAddresses first.
-	self assert: emailAddress address = 'sglazier@comcast.net'.
+	self assert: emailAddress address equals: 'sglazier@comcast.net'.
 	self assert: emailAddress isWork.
 	self assert: emailAddress isPreferred.
 	self deny: emailAddress isHome.
@@ -1158,7 +1158,7 @@ ICVCardTest >> testParseSean [
 	self deny: emailAddress isX400.
 	
 	emailAddress := card emailAddresses second.
-	self assert: emailAddress address = 'sglazier@comcast.net'.
+	self assert: emailAddress address equals: 'sglazier@comcast.net'.
 	self deny: emailAddress isWork.
 	self deny: emailAddress isPreferred.
 	self assert: emailAddress isHome.
@@ -1166,80 +1166,80 @@ ICVCardTest >> testParseSean [
 	self deny: emailAddress isX400.
 	
 	organization := card organization.
-	self assert: organization name = 'Cincom Systems'.
+	self assert: organization name equals: 'Cincom Systems'.
 	self assert: organization unitNames isEmpty.
 	
 ]
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testParseSurendar [
+
 	| cards card name imid organization |
 	cards := ICCardHandParser parseVCardString: self surendarCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
-	
-	self assert: card fullname = 'Surendar Chandra'.
-	self assert: card title = 'Asst. Professor'.
-	self assert: card version = 3.0.
+
+	self assert: card fullname equals: 'Surendar Chandra'.
+	self assert: card title equals: 'Asst. Professor'.
+	self assert: card version equals: 3.0.
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Chandra'.
-	self assert: name givenName = 'Surendar'.
+	self assert: name familyName equals: 'Chandra'.
+	self assert: name givenName equals: 'Surendar'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
-	
-	self assert: card aimids size = 1.
+
+	self assert: card aimids size equals: 1.
 	imid := card aimids anyOne.
 	self assert: (imid isKindOf: ICAIMId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'surendar'.
-	
+	self assert: imid id equals: 'surendar'.
+
 	self assert: card icqids isEmpty.
-	
-	self assert: card msnids size = 1.
+
+	self assert: card msnids size equals: 1.
 	imid := card msnids anyOne.
 	self assert: (imid isKindOf: ICMSNId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self assert: imid isHome.
-	self assert: imid id = 'surendar'.
-	
-	self assert: card yahooids size = 1.
+	self assert: imid id equals: 'surendar'.
+
+	self assert: card yahooids size equals: 1.
 	imid := card yahooids anyOne.
 	self assert: (imid isKindOf: ICYahooId).
 	self assert: imid isPreferred.
 	self assert: imid isWork.
 	self deny: imid isHome.
-	self assert: imid id = 'surendarcsdukeedu'.
-	
+	self assert: imid id equals: 'surendarcsdukeedu'.
+
 	organization := card organization.
-	self assert: organization name = 'Univ. of Notre Dame'.
-	self assert: organization unitNames size = 1.
-	self assert: organization unitNames anyOne = 'Computer Science and Engg'.
-	
-	self shouldnt: [ self assert: card notes size = 1 ] raise: Error.
-	self assert: card notes anyOne =
-'SMS message
+	self assert: organization name equals: 'Univ. of Notre Dame'.
+	self assert: organization unitNames size equals: 1.
+	self
+		assert: organization unitNames anyOne
+		equals: 'Computer Science and Engg'.
+	self assert: card notes size equals: 1.
+	self assert: card notes anyOne equals: 'SMS message
 12/22/2003 18:12
 wassup
 
 SMS message
 12/23/2003 13:12
 Hello'
-	
 ]
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testParseSurendarUrl [
 	| cards card |
 	cards := ICCardHandParser parseVCardString: self surendarCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 
-	self assert: card url asVCardString = 'http://www.cse.nd.edu/~surendar/'.
+	self assert: card url asVCardString equals: 'http://www.cse.nd.edu/~surendar/'.
 ]
 
 { #category : 'testing-parsing' }
@@ -1250,7 +1250,7 @@ ICVCardTest >> testParseWikipedia [
 	card := cards anyOne.
 	
 	self assert: card fullname equals: 'Firstname Lastname'.
-	self assert: card version equals: 2.1.
+	self assert: card version equals: 3.0.
 	name := card name.
 	self assert: name notNil.
 	self assert: name familyName equals: 'Lastname'.
@@ -1274,8 +1274,7 @@ ICVCardTest >> testParseWikipedia [
 	self assert: address locality isEmptyOrNil.
 	
 	self assert: address street equals: 'Bar Street 99'.
-	self assert: address extended equals: 'Footown 12345
-Fooland'.
+	self assert: address extended equals: 'Footown 12345, Fooland'.
 	self assert: address region isEmptyOrNil.
 	self assert: address postalcode isEmptyOrNil.
 	self assert: address country isEmptyOrNil.
@@ -1341,15 +1340,16 @@ ICVCardTest >> testUtcOffset [
 
 { #category : 'fixtures-parsing' }
 ICVCardTest >> wikipediaCardString [
-^
-'BEGIN:VCARD' , String crlf ,
-'VERSION:2.1' , String crlf ,
-'FN:Firstname Lastname' , String crlf ,
-'N:Lastname;Firstname' , String crlf ,
-'ADR;WORK;PREF;QUOTED-PRINTABLE:;Footown 12345=0AFooland;Bar Street 99' , String crlf ,
-'LABEL;QUOTED-PRINTABLE;WORK;PREF:Bar Street 99=0AFootown 12345=0AFooland' , String crlf ,
-'TEL;CELL:+358-40-123456' , String crlf ,
-'EMAIL;INTERNET:nobody@example.invalid' , String crlf ,
-'UID:' , String crlf ,
-'END:VCARD' , String crlf
+
+	^ 'BEGIN:VCARD
+VERSION:3.0
+FN:Firstname Lastname
+N:Lastname;Firstname
+ADR;TYPE=WORK;TYPE=PREF:;Footown 12345, Fooland;Bar Street 99
+LABEL;TYPE=WORK;TYPE=PREF:Bar Street 99, Footown 12345, Fooland
+TEL;TYPE=CELL:+358-40-123456
+EMAIL;TYPE=INTERNET:nobody@example.invalid
+UID:
+END:VCARD
+' lines joinUsing: String crlf
 ]

--- a/src/ICal-VCard-Tests/ICVCardTest.class.st
+++ b/src/ICal-VCard-Tests/ICVCardTest.class.st
@@ -227,14 +227,14 @@ ICVCardTest >> aviCardString [
 
 { #category : 'fixtures-exporting' }
 ICVCardTest >> aviCardStringExport [
-^
-'BEGIN:VCARD' , String crlf ,
+
+	^ 'BEGIN:VCARD' , String crlf ,
 'VERSION:3.0' , String crlf ,
 'N:Bryant;Avi;;;' , String crlf ,
 'FN:Avi Bryant' , String crlf ,
 'ADR;TYPE=home;TYPE=pref:;;xxx E. xx Ave;Vancouver;BC;V5V 1E3;Canada' , String crlf ,
 'TEL;TYPE=home;TYPE=pref:(778) xxx-xxxx' , String crlf ,
-'EMAIL;TYPE=pref;TYPE=internet;TYPE=work:avi@smallthought.com' , String crlf ,
+'EMAIL;TYPE=work;TYPE=internet;TYPE=pref:avi@smallthought.com' , String crlf ,
 'EMAIL;TYPE=internet;TYPE=home:avi.bryant@gmail.com' , String crlf ,
 'TZ:-05:00' , String crlf ,
 'X-AIM;TYPE=pref:avbry' , String crlf ,
@@ -304,9 +304,9 @@ ICVCardTest >> goofyCardStringExport [
 'FN:Markus Tschannen' , String crlf ,
 'BDAY:1980-10-30' , String crlf ,
 'ADR;TYPE=home:;;Neufeldstrasse 11;Bern;;3012;Schweiz' , String crlf ,
-'TEL;TYPE=home;TYPE=voice:+41 31 302 08 56' , String crlf ,
-'TEL;TYPE=cell;TYPE=home:+41 78 845 24 12' , String crlf ,
-'TZ;VALUE=TEXT:-05:00\\; EST\\; Raleigh/North America' , String crlf ,
+'TEL;TYPE=voice;TYPE=home:+41 31 302 08 56' , String crlf ,
+'TEL;TYPE=home;TYPE=cell:+41 78 845 24 12' , String crlf ,
+'TZ;VALUE=TEXT:-05:00\; EST\; Raleigh/North America' , String crlf ,
 'GEO:37.386013;-122.082932' , String crlf ,
 'END:VCARD' , String crlf
 ]
@@ -346,7 +346,7 @@ ICVCardTest >> maeveCardString [
 'item1.X-ABADR:us' , String crlf ,
 'item2.URL;type=pref:http\://www.zenediting.com' , String crlf ,
 'item2.X-ABLabel:_$!<HomePage>!$_' , String crlf ,
-'item3.URL:http\://www.myspace.com/maeveprice' , String crlf ,
+'item3.URL:http://www.myspace.com/maeveprice' , String crlf ,
 'item3.X-ABLabel:my space' , String crlf ,
 'BDAY;value=date:2005-06-14' , String crlf ,
 'X-AIM;type=HOME;type=pref:Mahaevey' , String crlf ,
@@ -522,36 +522,34 @@ ICVCardTest >> surendarCardString [
 
 { #category : 'testing-exporting' }
 ICVCardTest >> testExportAvi [
+
 	| cards exporter str |
 	cards := ICCardHandParser parseVCardString: self aviCardString.
 	cards anyOne photo: nil.
-	
+
 	exporter := ICVCardExporter cards: cards.
 	exporter export.
 	str := self aviCardStringExport.
 
-	exporter dataStream contents 
-		keysAndValuesDo: [:index :value |
-			self assert: value = (str at: index) ].
-	self assert: exporter dataStream contents = str.
-	
+	exporter dataStream contents keysAndValuesDo: [ :index :value |
+		self assert: value equals: (str at: index) ].
+	self assert: exporter dataStream contents equals: str
 ]
 
 { #category : 'testing-exporting' }
 ICVCardTest >> testExportGoofy [
+
 	| cards exporter str |
 	cards := ICCardHandParser parseVCardString: self goofyCardString.
 	cards anyOne photo: nil.
-	
+
 	exporter := ICVCardExporter cards: cards.
 	exporter export.
 	str := self goofyCardStringExport.
 
-	exporter dataStream contents 
-		keysAndValuesDo: [:index :value |
-			self assert: value = (str at: index) ].
-	self assert: exporter dataStream contents = str.
-	
+	exporter dataStream contents keysAndValuesDo: [ :index :value |
+		self assert: value equals: (str at: index) ].
+	self assert: exporter dataStream contents equals: str
 ]
 
 { #category : 'testing-exporting' }
@@ -571,52 +569,55 @@ ICVCardTest >> testIsOrganization [
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testName [
+
 	| name |
 	name := ICName fromICalString: 'Public;John;Quinlan;Mr.;Esq'.
-	self assert: name familyName = 	'Public'.
-	self assert: name givenName = 	'John'.
-	self assert: name additionalNames size = 1.
-	self assert: name additionalNames first = 'Quinlan'.
-	self assert: name honorificPrefixes size = 1.
-	self assert: name honorificPrefixes first = 'Mr.'.
-	self assert: name honorificSuffixes size = 1.
-	self assert: name honorificSuffixes first = 'Esq'.
+
+	self assert: name familyName equals: 'Public'.
+	self assert: name givenName equals: 'John'.
+	self assert: name additionalNames size equals: 1.
+	self assert: name additionalNames first equals: 'Quinlan'.
+	self assert: name honorificPrefixes size equals: 1.
+	self assert: name honorificPrefixes first equals: 'Mr.'.
+	self assert: name honorificSuffixes size equals: 1.
+	self assert: name honorificSuffixes first equals: 'Esq'.
 
 	name := ICName fromICalString: 'Stevenson;John;Philip,Paul;Dr.;Jr.,M.D.,A.C.P.'.
-	self assert: name familyName = 	'Stevenson'.
-	self assert: name givenName = 	'John'.
-		
-	self assert: name additionalNames size = 2.
-	self assert: name additionalNames first = 'Philip'.
-	self assert: name additionalNames second = 'Paul'.
-	
-	self assert: name honorificPrefixes size = 1.
-	self assert: name honorificPrefixes first = 'Dr.'.
-	
-	self assert: name honorificSuffixes size = 3.
-	self assert: name honorificSuffixes first = 'Jr.'.
-	self assert: name honorificSuffixes second = 'M.D.'.
-	self assert: name honorificSuffixes third = 'A.C.P.'.
+	self assert: name familyName equals: 'Stevenson'.
+	self assert: name givenName equals: 'John'.
+
+	self assert: name additionalNames size equals: 2.
+	self assert: name additionalNames first equals: 'Philip'.
+	self assert: name additionalNames second equals: 'Paul'.
+	self assert: name honorificPrefixes size equals: 1.
+	self assert: name honorificPrefixes first equals: 'Dr.'.
+
+	self assert: name honorificSuffixes size equals: 3.
+	self assert: name honorificSuffixes first equals: 'Jr.'.
+	self assert: name honorificSuffixes second equals: 'M.D.'.
+	self assert: name honorificSuffixes third equals: 'A.C.P.'
 ]
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testParseAvi [
 	| cards card address name phoneNumber emailAddress imid |
+	
 	cards := ICCardHandParser parseVCardString: self aviCardString.
-	self assert: cards size = 1.
+
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Avi Bryant'.
-	self assert: card version = 3.0.
+	self assert: card fullname equals: 'Avi Bryant'.
+	self assert: card version equals: 3.0.
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Bryant'.
-	self assert: name givenName = 'Avi'.
+	self assert: name familyName equals: 'Bryant'.
+	self assert: name givenName equals: 'Avi'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card addresses size = 1.
+	self assert: card addresses size equals: 1.
 	address := card addresses anyOne.
 	
 	self assert: address isHome.
@@ -630,15 +631,15 @@ ICVCardTest >> testParseAvi [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address extended isEmptyOrNil.
 	
-	self assert: address street = 'xxx E. xx Ave'.
-	self assert: address locality = 'Vancouver'.
-	self assert: address region = 'BC'.
-	self assert: address postalcode = 'V5V 1E3'.
-	self assert: address country = 'Canada'.
+	self assert: address street equals: 'xxx E. xx Ave'.
+	self assert: address locality equals: 'Vancouver'.
+	self assert: address region equals: 'BC'.
+	self assert: address postalcode equals: 'V5V 1E3'.
+	self assert: address country equals: 'Canada'.
 	
-	self assert: card phoneNumbers size = 1.
+	self assert: card phoneNumbers size equals: 1.
 	phoneNumber := card phoneNumbers first.
-	self assert: phoneNumber number = '(778) xxx-xxxx'.
+	self assert: phoneNumber number equals: '(778) xxx-xxxx'.
 	self assert: phoneNumber isHome.
 	self assert: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -652,9 +653,9 @@ ICVCardTest >> testParseAvi [
 	self deny: phoneNumber isVoice.
 	self deny: phoneNumber isVoiceMessage.
 	
-	self assert: card emailAddresses size = 2.
+	self assert: card emailAddresses size equals: 2.
 	emailAddress := card emailAddresses first.
-	self assert: emailAddress address = 'avi@smallthought.com'.
+	self assert: emailAddress address equals: 'avi@smallthought.com'.
 	self assert: emailAddress isWork.
 	self assert: emailAddress isPreferred.
 	self deny: emailAddress isHome.
@@ -662,36 +663,36 @@ ICVCardTest >> testParseAvi [
 	self deny: emailAddress isX400.
 	
 	emailAddress := card emailAddresses second.
-	self assert: emailAddress address = 'avi.bryant@gmail.com'.
+	self assert: emailAddress address equals: 'avi.bryant@gmail.com'.
 	self deny: emailAddress isWork.
 	self deny: emailAddress isPreferred.
 	self assert: emailAddress isHome.
 	self assert: emailAddress isInternet.
 	self deny: emailAddress isX400.
 	
-	self assert: card photo iCalType = 'BINARY'.
+	self assert: card photo iCalType equals: 'BINARY'.
 	
-	self assert: card aimids size = 1.
+	self assert: card aimids size equals: 1.
 	imid := card aimids anyOne.
 	self assert: (imid isKindOf: ICAIMId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self deny: imid isHome.
-	self assert: imid id = 'avbry'.
+	self assert: imid id equals: 'avbry'.
 	
 	self assert: card icqids isEmpty.
 	
-	self assert: card msnids size = 1.
+	self assert: card msnids size equals: 1.
 	imid := card msnids anyOne.
 	self assert: (imid isKindOf: ICMSNId).
 	self assert: imid isPreferred.
 	self deny: imid isWork.
 	self deny: imid isHome.
-	self assert: imid id = 'avi666@hotmail.com'.
+	self assert: imid id equals: 'avi666@hotmail.com'.
 	
 	self assert: card yahooids isEmpty.
 	self assert: (card timeZone isKindOf: ICUtcOffset).
-	self assert: (card timeZone totalSeconds = (5 * 60 * 60) negated)
+	self assert: card timeZone totalSeconds equals: (5 * 60 * 60) negated
 	
 ]
 
@@ -866,12 +867,16 @@ ICVCardTest >> testParseMaeve [
 
 { #category : 'testing-parsing' }
 ICVCardTest >> testParseMaeveUrl [
+	"The vCard uses backslashes (\) to escape characters in URLs, which is not compliant with the vCard 3.0 specification. According to RFC 6350, URLs should be encoded properly without needing to escape characters. For example, spaces in URLs should be encoded as %20 instead of being escaped with a backslash."
+
 	| cards card |
 	cards := ICCardHandParser parseVCardString: self maeveCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
-	
-	self assert: card url asVCardString equals: 'http://http\:0/www.myspace.com/maeveprice'.	
+
+	self
+		assert: card url asVCardString
+		equals: 'http://www.myspace.com/maeveprice'
 ]
 
 { #category : 'testing-parsing' }
@@ -1241,20 +1246,20 @@ ICVCardTest >> testParseSurendarUrl [
 ICVCardTest >> testParseWikipedia [
 	| cards card address name phoneNumber emailAddress |
 	cards := ICCardHandParser parseVCardString: self wikipediaCardString.
-	self assert: cards size = 1.
+	self assert: cards size equals: 1.
 	card := cards anyOne.
 	
-	self assert: card fullname = 'Firstname Lastname'.
-	self assert: card version = 2.1.
+	self assert: card fullname equals: 'Firstname Lastname'.
+	self assert: card version equals: 2.1.
 	name := card name.
 	self assert: name notNil.
-	self assert: name familyName = 'Lastname'.
-	self assert: name givenName = 'Firstname'.
+	self assert: name familyName equals: 'Lastname'.
+	self assert: name givenName equals: 'Firstname'.
 	self assert: name additionalNames isEmptyOrNil.
 	self assert: name honorificPrefixes isEmptyOrNil.
 	self assert: name honorificSuffixes isEmptyOrNil.
 	
-	self assert: card addresses size = 1.
+	self assert: card addresses size equals: 1.
 	address := card addresses anyOne.
 	
 	self deny: address isHome.
@@ -1268,16 +1273,16 @@ ICVCardTest >> testParseWikipedia [
 	self assert: address poBox isEmptyOrNil.
 	self assert: address locality isEmptyOrNil.
 	
-	self assert: address street = 'Bar Street 99'.
-	self assert: address extended = 'Footown 12345
+	self assert: address street equals: 'Bar Street 99'.
+	self assert: address extended equals: 'Footown 12345
 Fooland'.
 	self assert: address region isEmptyOrNil.
 	self assert: address postalcode isEmptyOrNil.
 	self assert: address country isEmptyOrNil.
 	
-	self assert: card phoneNumbers size = 1.
+	self assert: card phoneNumbers size equals: 1.
 	phoneNumber := card phoneNumbers first.
-	self assert: phoneNumber number = '+358-40-123456'.
+	self assert: phoneNumber number equals: '+358-40-123456'.
 	self deny: phoneNumber isHome.
 	self deny: phoneNumber isPreferred.
 	self deny: phoneNumber isWork.
@@ -1292,9 +1297,9 @@ Fooland'.
 	self deny: phoneNumber isVoiceMessage.
 
 	
-	self assert: card emailAddresses size = 1.
+	self assert: card emailAddresses size equals: 1.
 	emailAddress := card emailAddresses first.
-	self assert: emailAddress address = 'nobody@example.invalid'.
+	self assert: emailAddress address equals: 'nobody@example.invalid'.
 	self deny: emailAddress isWork.
 	self deny: emailAddress isPreferred.
 	self deny: emailAddress isHome.
@@ -1307,31 +1312,31 @@ ICVCardTest >> testUtcOffset [
 	| offset |
 	offset := ICUtcOffset fromVCardString: '-05:00'.
 	self deny: offset positive.
-	self assert: offset hours = 5.
-	self assert: offset minutes = 0.
-	self assert: offset seconds = 0.
-	self assert: '-05:00'  = offset asVCardString.
+	self assert: offset hours equals: 5.
+	self assert: offset minutes equals: 0.
+	self assert: offset seconds equals: 0.
+	self assert: '-05:00'  equals: offset asVCardString.
 
 	offset := ICUtcOffset fromVCardString: '+01:00'.
 	self assert: offset positive.
-	self assert: offset hours = 1.
-	self assert: offset minutes = 0.
-	self assert: offset seconds = 0.
-	self assert: '+01:00'  = offset asVCardString.
+	self assert: offset hours equals: 1.
+	self assert: offset minutes equals: 0.
+	self assert: offset seconds equals: 0.
+	self assert: '+01:00'  equals: offset asVCardString.
 	
 	offset := ICUtcOffset fromVCardString: '+01:05'.
 	self assert: offset positive.
-	self assert: offset hours = 1.
-	self assert: offset minutes = 5.
-	self assert: offset seconds = 0.
-	self assert: '+01:05'  = offset asVCardString.
+	self assert: offset hours equals: 1.
+	self assert: offset minutes equals: 5.
+	self assert: offset seconds equals: 0.
+	self assert: '+01:05'  equals: offset asVCardString.
 	
 	offset := ICUtcOffset fromVCardString: '-01:05'.
 	self deny: offset positive.
-	self assert: offset hours = 1.
-	self assert: offset minutes = 5.
-	self assert: offset seconds = 0.
-	self assert: '-01:05'  = offset asVCardString.
+	self assert: offset hours equals: 1.
+	self assert: offset minutes equals: 5.
+	self assert: offset seconds equals: 0.
+	self assert: '-01:05'  equals: offset asVCardString.
 ]
 
 { #category : 'fixtures-parsing' }

--- a/src/ICal-VCard/ICCardHandParser.class.st
+++ b/src/ICal-VCard/ICCardHandParser.class.st
@@ -11,7 +11,8 @@ Class {
 
 { #category : 'instance creation' }
 ICCardHandParser class >> parseVCardFile: aPath [
-	^self parseVCardString: (FileStream readOnlyFileNamed: aPath) contentsOfEntireFile
+
+	^ self parseVCardString: aPath asFileReference contents
 ]
 
 { #category : 'instance creation' }

--- a/src/ICal-VCard/ICTypedObject.class.st
+++ b/src/ICal-VCard/ICTypedObject.class.st
@@ -21,9 +21,10 @@ ICTypedObject class >> iCalType [
 
 { #category : 'private' }
 ICTypedObject class >> parseTypes: aDictionary [
-	^((aDictionary includesKey: 'TYPE')
-		ifTrue: [ ((aDictionary at: 'TYPE') collect: [ :each | each asLowercase]) asSet ]
-		ifFalse: [ self defaultTypes ]).
+
+	^ (aDictionary includesKey: 'TYPE')
+		ifTrue: [ ((aDictionary at: 'TYPE') collect: #asLowercase) asSet ]
+		ifFalse: [ self defaultTypes ]
 ]
 
 { #category : 'accessing-types' }

--- a/src/ICal/ByteArray.extension.st
+++ b/src/ICal/ByteArray.extension.st
@@ -17,9 +17,7 @@ ByteArray >> exportICalParametersOn: anExpoter [
 { #category : '*ICal' }
 ByteArray class >> fromICalString: aString [
 
-	^ (Base64MimeConverter mimeDecodeToChars: 
-		(ReadStream on: aString))
-			contents
+	^ (Base64MimeConverter mimeDecodeToChars: (ReadStream on: aString)) 	contents asByteArray
 ]
 
 { #category : '*ICal' }

--- a/src/ICal/ICGenerator.class.st
+++ b/src/ICal/ICGenerator.class.st
@@ -54,7 +54,7 @@ ICGenerator >> createValue: aString parameters: aDictionary type: iCalType [
 		fromICalString: aString parameters: aDictionary
 ]
 
-{ #category : 'dispatching' }
+{ #category : 'reflective operations' }
 ICGenerator >> doesNotUnderstand: aMessage [
 	| property |
 	^((aMessage selector endsWith: 'parameters:')

--- a/src/ICal/ICTrigger.class.st
+++ b/src/ICal/ICTrigger.class.st
@@ -61,9 +61,10 @@ ICTrigger >> exportICalParametersOn: anExpoter [
 
 { #category : 'accessing' }
 ICTrigger >> iCalType [
-	^self value isNil
-		ifTrue: [ self class iCalType ]
-		ifFalse: [ self value iCalType ]
+
+	^ self value
+		  ifNil: [ self class iCalType ]
+		  ifNotNil: [ self value iCalType ]
 ]
 
 { #category : 'testing' }

--- a/src/ICal/String.extension.st
+++ b/src/ICal/String.extension.st
@@ -38,6 +38,8 @@ String >> asVCardString [
 
 { #category : '*ICal' }
 String class >> fromICalString: aString [
+	"Parse aString according to the vCard 3.0 specification"
+
 	^ self fromNewString: aString 
 ]
 


### PR DESCRIPTION
- These fixes now make all VCard tests to pass.
	- Fix the parser answering a ByteArray for encoded photos instead of a String.
	- Fix the use of double backslashes (\\) is not compliant with the vCard 2.1 specification.
	- Fix usage of backslashes (\) to escape characters in URLs, which is not compliant with the vCard 3.0 specification. According to RFC 6350, URLs should be encoded properly without needing to escape characters.
	- Update failing tests to use the vCard 3.0 specification.
	- Fix test to check that each exported line does not exceed the length of 75 characters.
- Use assert:equals: instead of =
- Fix some tests using = as line ending.
- Update Wikipedia card to use the 3.0 version.
